### PR TITLE
add date/time, button link to eventbrite page

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,16 +6,15 @@ layout: default
   <div class="pane main h-event">
     <div class="pane-content">
       <h1 class="p-name">Taste of Code</h1>
-      <p>Looking for our next location...</p>
-      <!-- <p>
+      <p>
         <time class="dt-start" datetime="2016-11-01 19:00">
-          01/11/2016&emsp;19:00
+          21/01/2017&emsp;10:00
         </time>
         -
         <time class="dt-end" datetime="2016-11-01 20:00">
-          20:00
+          16:00
         </time>
-      </p> -->
+      </p>
       <p class="p-location">
         KPN
         <br>
@@ -32,11 +31,9 @@ layout: default
       <!-- <a href="https://www.eventbrite.nl/e/tickets-taste-of-code-tq-27431178393" class="button primary">
         Sign Up Now
       </a> -->
-      <a href="mailto:support@codaisseur.com?subject=Organize%20a%20Taste%20of%20Code" class="button primary">
-        Contact Us
+      <a href="https://www.eventbrite.nl/e/tickets-taste-of-code-kpn-29854120478" target="_blank" class="button primary">
+        Sign Up
       </a>
-      <!-- <small>Bring a Laptop | Max 100 Participants</small> -->
-      <small>Host an awesome event | Min 40 participants</small>
       </p>
     </div>
 


### PR DESCRIPTION
The following updates have been made:

- Removed the following text
![toc-text](https://cloud.githubusercontent.com/assets/16960228/21006451/44dc7472-bd39-11e6-90ee-c9870f3ee4e9.png)

- Add the date and time
![toc-date-time](https://cloud.githubusercontent.com/assets/16960228/21006501/7631b44c-bd39-11e6-94d3-ecc66a8645a1.png)

- Changed link for button to direct users to ToC sign up page on Eventbrite