### PR TITLE
Add video with offest for highest resolution.

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,6 @@ layout: default
         <p>&nbsp;&nbsp;&nbsp;&nbsp;<span class="argument">■■■</span></p>
         <p>&nbsp;&nbsp;<span class="switch">■■■</span></p>
         <p><span class="switch">■■■</span></p>
-        </pre>
       </div>
     </div>
   </div>
@@ -174,6 +173,15 @@ layout: default
     <div class="content-column">
       <h2>Where?</h2>
       <p><strong>Leading tech minded corporates</strong> provide us with classroom space and sponsorships, and <strong>Codaisseur</strong> provides us with a training program and expert coaching throughout the day.</p>
+    </div>
+
+    <div class="white-space">
+    </div>
+
+    <div class="content-row">
+      <div class="col-lg-offset-1 col-lg-10 embed-responsive embed-responsive-16by9">
+        <iframe class="embed-responsive-item" src="https://player.vimeo.com/video/201633032" frameborder="0" allowfullscreen></iframe>
+      </div>
     </div>
 
     <div class="white-space">


### PR DESCRIPTION
Removed a closing tag for `pre` that didn't have an opening tag, and added the ToC video from the Codaisseur Vimeo channel.  The videos looked alright with the default responsive sizing apart from the largest, so I added a column offset of 1 there.