### PR TITLE
remove old toc event info

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,19 +8,21 @@ layout: default
       <h1 class="p-name">Taste of Code</h1>
       <p>
         <time class="dt-start" datetime="2016-11-01 19:00">
-          21/01/2017&emsp;10:00
+          <!-- 21/01/2017&emsp;10:00 -->
+          STAY TUNED!
         </time>
-        -
+        <!-- -
         <time class="dt-end" datetime="2016-11-01 20:00">
           16:00
-        </time>
+        </time> -->
       </p>
       <p class="p-location">
-        KPN
-        <br>
+        The next Taste of Code is in the works...
+        <!-- KPN -->
+        <!-- <br>
         Teleportboulevard 121
         <br>
-        1043 EJ Amsterdam
+        1043 EJ Amsterdam -->
       </p>
 
       <!-- <p><span class="label label-danger">Fully Booked!</span></p> -->
@@ -28,15 +30,15 @@ layout: default
       <!-- <p>The current event is fully booked, but you can sign up for the waiting list below to stay updated on future events.</p> -->
 
       <p class="cta" id="signupCTA">
-      <!-- <a href="https://www.eventbrite.nl/e/tickets-taste-of-code-tq-27431178393" class="button primary">
-        Sign Up Now
-      </a> -->
-      <a href="https://www.eventbrite.nl/e/tickets-taste-of-code-kpn-29854120478" target="_blank" class="button primary">
+      <a href="https://www.eventbrite.nl/e/tickets-taste-of-code-kpn-29854120478" target="_blank" class="button primary" disabled>
+        <!-- to re-enable button remove to following from _form.sass:
+            pointer-events: none
+            cursor: default -->
         Sign Up
       </a>
       </p>
       <p>
-        <small>Bring a Laptop | Max 120 Participants</small>
+        <!-- <small>Bring a Laptop | Max 120 Participants</small> -->
       </p>
     </div>
 

--- a/sass/components/_form.sass
+++ b/sass/components/_form.sass
@@ -8,6 +8,8 @@ input.button.primary
   display: block
   width: 60%
   margin: 2em auto 1em
+  pointer-events: none
+  cursor: default
 
   &:hover
     background-color: $primary-button-hover-color


### PR DESCRIPTION
Removed old ToC event info and replaced with a message to stay tuned. Also disabled the sign-up button.

![disabled](https://cloud.githubusercontent.com/assets/16960228/22598038/5627e7c2-ea32-11e6-986a-8231a4aa7695.png)
