### PR TITLE
Remove sign up reference to previous ToC

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ layout: default
   <div class="pane main h-event">
     <div class="pane-content">
       <h1 class="p-name">Taste of Code</h1>
-      <p class="p-sponsor">Sponsored by Codaisseur</p>
+      <!-- <p class="p-sponsor">Sponsored by Codaisseur</p>
 
       <p>
         <time class="dt-start" datetime="2017-21-04 10:00">
@@ -16,27 +16,27 @@ layout: default
         <time class="dt-end" datetime="2017-21-04 16:00">
           16:00
         </time>
-      </p>
+      </p> -->
 
       <p class="p-location">
-      <!-- The next Taste of Code is in the works! Please stay tuned. -->
-        Codaisseur
+      The next Taste of Code is in the works! Please stay tuned.
+        <!-- Codaisseur
         <br>
         Burgerweeshuispad 201
         <br>
-        1076 GR Amsterdam
+        1076 GR Amsterdam -->
       </p>
 
       <!-- <p><span class="label label-danger">Fully Booked!</span></p> -->
 
       <!-- <p>The current event is fully booked, but you can sign up for the waiting list below to stay updated on future events.</p> -->
 
-      <p class="cta" id="signupCTA">
+      <!-- <p class="cta" id="signupCTA">
         <a href="https://www.eventbrite.nl/e/tickets-taste-of-code-at-codaisseur-44145490350" target="_blank" class="button primary">Sign Up</a>
       </p>
       <p>
         <small>Bring a Laptop | Max 100 Participants</small>
-      </p>
+      </p> -->
     </div>
 
     <div class="signup-form" style="display: none">


### PR DESCRIPTION
Removed information relating to the last ToC that is now outdated:

![in_the_works](https://user-images.githubusercontent.com/16960228/39436366-0f1c57d0-4c9e-11e8-847e-c8a7349c3d91.png)
